### PR TITLE
Added encoding for wordlist so tilde characters won't crash exec…

### DIFF
--- a/xmlrpc-bruteforcer.py
+++ b/xmlrpc-bruteforcer.py
@@ -139,7 +139,7 @@ def parse_args():
     parser.add_argument("-t", "--thread", dest = "threads_number", help = "number of threads to run", default = 5, type = int)
     parser.add_argument("-u", "--username", dest = "username", help = "username of the targeted user,", required = True)
     parser.add_argument("-v", "--verbose", dest = "verbose", help = "print debugging information", action='store_true') 
-    parser.add_argument("-w", "--wordlist", dest = "wordlist", help = "wordlist containing the passwords", required = True, type = argparse.FileType('r', encoding='latin-1')) 
+    parser.add_argument("-w", "--wordlist", dest = "wordlist", help = "wordlist containing the passwords", required = True, type = argparse.FileType('rb')) 
     parser.add_argument("-x", "--xml-rpc", dest = "xmlrpc_intf", help = "xmlrpc interface to attack", required = True) 
    
     return parser.parse_args()

--- a/xmlrpc-bruteforcer.py
+++ b/xmlrpc-bruteforcer.py
@@ -139,7 +139,7 @@ def parse_args():
     parser.add_argument("-t", "--thread", dest = "threads_number", help = "number of threads to run", default = 5, type = int)
     parser.add_argument("-u", "--username", dest = "username", help = "username of the targeted user,", required = True)
     parser.add_argument("-v", "--verbose", dest = "verbose", help = "print debugging information", action='store_true') 
-    parser.add_argument("-w", "--wordlist", dest = "wordlist", help = "wordlist containing the passwords", required = True, type = argparse.FileType('r')) 
+    parser.add_argument("-w", "--wordlist", dest = "wordlist", help = "wordlist containing the passwords", required = True, type = argparse.FileType('r', encoding='latin-1')) 
     parser.add_argument("-x", "--xml-rpc", dest = "xmlrpc_intf", help = "xmlrpc interface to attack", required = True) 
    
     return parser.parse_args()


### PR DESCRIPTION
If you run a popular wordlist like rockyou, the script throws an error like:

argparse UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf1 in position 923: invalid continuation byte

Added latin-1 encoding and now script runs smoothly.

Cheers,